### PR TITLE
Addition of Rackspace Queues

### DIFF
--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -22,3 +22,6 @@ rackspace:
 agents:
   rackspace_lb:
     enabled: true
+
+  rackspace_q:
+    enabled: true

--- a/lib/newrelic_rackspace_plugin/agent_plugin.rb
+++ b/lib/newrelic_rackspace_plugin/agent_plugin.rb
@@ -106,7 +106,7 @@ module NewRelicRackspacePlugin
     # Returns the requested type of fog connection to the rackspace
     # API. Currently supported types:
     #   :compute, :blockstorage, :storage, :loadbalancers, :databases
-    #   :cloud_monitoring, :dns, :cdn
+    #   :cloud_monitoring, :dns, :cdn, :queues
     def fog(type)
       stype = type.to_sym
       require 'fog' unless @fog
@@ -137,6 +137,8 @@ module NewRelicRackspacePlugin
           klass = Fog::CDN::Rackspace
         when :dns
           klass = Fog::DNS::Rackspace
+        when :queues
+          klass = Fog::Rackspace::Queues
         else
           raise ArgumentError.new "Invalid fog connection type received: #{type}"
         end

--- a/lib/newrelic_rackspace_q.rb
+++ b/lib/newrelic_rackspace_q.rb
@@ -1,0 +1,1 @@
+require 'newrelic_rackspace_q/agent'

--- a/lib/newrelic_rackspace_q/agent.rb
+++ b/lib/newrelic_rackspace_q/agent.rb
@@ -1,0 +1,40 @@
+require 'newrelic_rackspace_plugin/agent_plugin'
+require 'newrelic_rackspace_q/version'
+
+require 'json'
+
+module NewRelicRackspacePlugin
+  class PluginAgent
+    module Q
+      class Agent < PluginAgent
+
+        agent_version NewRelicRackspacePlugin::Q::VERSION.version
+        agent_guid 'com.newrelic.rackspace.q_overview'
+        agent_human_labels('Rackspace Q'){ 'Rackspace Queues' }
+
+        def poll_cycle
+          log_errors do
+            list_queues_hash = JSON.parse(fog(:queues).list_queues.body)
+
+            list_queues_hash['queues'].each do |q|
+              q.each do |k_queue, v_queue|
+                log.warn "Fetching stats information for queue: #{v_queue}"
+
+                if k_queue == "name"
+                  get_queue_stats_hash = JSON.parse(fog(:queues).get_queue_stats(v_queue).body)
+
+                  get_queue_stats_hash['messages'].each do |k_stats, v_stats|
+                    #all, claimed, free
+                    report_metric k_stats, 'messages', v_stats, :name => v_queue
+                  end    
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+NewRelic::Plugin::Setup.install_agent :rackspace_q, NewRelicRackspacePlugin::PluginAgent::Q

--- a/lib/newrelic_rackspace_q/version.rb
+++ b/lib/newrelic_rackspace_q/version.rb
@@ -1,0 +1,9 @@
+module NewRelicRackspacePlugin
+  module Q
+    
+    class Version < Gem::Version
+    end
+
+    VERSION = Version.new('0.0.1')
+  end
+end


### PR DESCRIPTION
Hi there,

other than keeping an eye on Rackspace Load Balancers, it would be great to be able to keep an eye on Rackspace Queues. I've added this functionality into my "newrelic_rackspace_plugin"-fork (due to the fact it is no longer load_balancers-specific).

Thanks in advance for merging this PR, don't hesitate to get back to me for more information!

Kind regards,
David
